### PR TITLE
Adding Time Rush Gadget as an Item

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -15,7 +15,8 @@ def gen_powerups(world: "Sly2World") -> list[Item]:
     for item_name in item_groups["Power-Up"]:
         if (
             (item_name == "TOM" and not world.options.include_tom) or
-            (item_name == "Mega Jump" and not world.options.include_mega_jump)
+            (item_name == "Mega Jump" and not world.options.include_mega_jump) or
+            (item_name == "Time Rush" and not world.options.include_time_rush)
         ):
             continue
         else:

--- a/Rules.py
+++ b/Rules.py
@@ -89,7 +89,8 @@ def set_rules(world: "Sly2World"):
                     state.has("Feral Pounce", player) or
                     state.has("Hover Pack", player)  or
                     state.has("Turnbuckle Launch", player) # or
-                    # state.has("Progressive Anatomy for Disaster", player, 3) # Obtainable during Mega Jump Job
+                    # state.has("Progressive Anatomy for Disaster", player, 3)
+                    # Obtainable during Mega Jump Job. If jobs were replayable, this rule COULD be applied if desired.
                 )
             )
         else:
@@ -110,7 +111,8 @@ def set_rules(world: "Sly2World"):
                     state.has("Feral Pounce", player) or
                     state.has("Hover Pack", player) or
                     state.has("Turnbuckle Launch", player) # or
-                    # state.has("Progressive Anatomy for Disaster", player, 3) # Obtainable during Mega Jump Job
+                    # state.has("Progressive Anatomy for Disaster", player, 3)
+                    # Obtainable during Mega Jump Job. If jobs were replayable, this rule COULD be applied if desired.
                     
                 )
             )

--- a/Sly 2.yaml
+++ b/Sly 2.yaml
@@ -124,13 +124,18 @@ requires:
 
   ## Items
 
-  # Add the TOM ability to the pool.
+  # Add the TOM ability/gadget to the pool.
   include_tom:
     'false': 50
     'true': 0
 
-  # Add the Mega Jump ability to the pool.
+  # Add the Mega Jump ability/gadget to the pool.
   include_mega_jump:
+    'false': 50
+    'true': 0
+
+  # Add the Time Rush ability/gadget to the pool.
+  include_time_rush:
     'false': 50
     'true': 0
 

--- a/Sly2Options.py
+++ b/Sly2Options.py
@@ -110,7 +110,7 @@ class RequiredKeysGoal(Range):
 
 class IncludeTOM(Toggle):
     """
-    Add the TOM ability to the pool.
+    Add the TOM ability/gadget to the pool.
     """
 
     display_name = "Include TOM"
@@ -118,10 +118,18 @@ class IncludeTOM(Toggle):
 
 class IncludeMegaJump(Toggle):
     """
-    Add the Mega Jump ability to the pool.
+    Add the Mega Jump ability/gadget to the pool.
     """
 
     display_name = "Include Mega Jump"
+
+
+class IncludeTimeRush(Toggle):
+    """
+    Add the Time Rush ability/gadget to the pool.
+    """
+
+    display_name = "Include Time Rush"
 
 
 class CoinsMinimum(Range):
@@ -235,6 +243,7 @@ class Sly2Options(PerGameCommonOptions):
     required_keys_goal: RequiredKeysGoal
     include_tom: IncludeTOM
     include_mega_jump: IncludeMegaJump
+    include_time_rush: IncludeTimeRush
     coins_minimum: CoinsMinimum
     coins_maximum: CoinsMaximum
     include_vaults: IncludeVaults
@@ -259,6 +268,7 @@ sly2_option_groups = [
     OptionGroup("Items",[
         IncludeTOM,
         IncludeMegaJump,
+        IncludeTimeRush,
         CoinsMinimum,
         CoinsMaximum,
         BottleItemBundleSize

--- a/__init__.py
+++ b/__init__.py
@@ -186,15 +186,16 @@ class Sly2World(World):
                     self.options.required_keys_goal.value = slot_data["required_keys_goal"]
                     self.options.include_tom.value = slot_data["include_tom"]
                     self.options.include_mega_jump.value = slot_data["include_mega_jump"]
+                    self.options.include_time_rush.value = slot_data["include_time_rush"]
                     self.options.coins_minimum.value = slot_data["coins_minimum"]
                     self.options.coins_maximum.value = slot_data["coins_maximum"]
                     self.options.thiefnet_minimum.value = slot_data["thiefnet_minimum"]
                     self.options.thiefnet_maximum.value = slot_data["thiefnet_maximum"]
                     self.options.include_vaults.value = slot_data["include_vaults"]
+                    self.options.bottle_item_bundle_size.value = slot_data["bottle_item_bundle_size"]
                     self.options.bottle_location_bundle_size.value = slot_data["bottle_location_bundle_size"]
                     self.options.bottlesanity.value = slot_data["bottlesanity"]
                     self.options.scout_thiefnet.value = slot_data["scout_thiefnet"]
-                    self.options.bottle_item_bundle_size.value = slot_data["bottle_item_bundle_size"]
             return
 
         self.validate_options(self.options)
@@ -245,6 +246,7 @@ class Sly2World(World):
             "required_keys_goal",
             "include_tom",
             "include_mega_jump",
+            "include_time_rush",
             "coins_minimum",
             "coins_maximum",
             "thiefnet_minimum",

--- a/data/Items.py
+++ b/data/Items.py
@@ -39,6 +39,7 @@ powerup_list = [
     ("Shadow Power",            ItemClassification.useful,      "Power-Up"),
     ("TOM",                     ItemClassification.useful,      "Power-Up"),
     ("Mega Jump",               ItemClassification.progression, "Power-Up"),
+    ("Time Rush",               ItemClassification.useful,      "Power-Up"),
 
     ("Trigger Bomb",            ItemClassification.useful,      "Power-Up"),
     ("Size Destabilizer",       ItemClassification.useful,      "Power-Up"),


### PR DESCRIPTION
I wasn't sure if I was going to need to mess with the powerup methods in the Sly2Interface.py file, but luckily the near initial implementation already takes the Time Rush Gadget into account. Because of this, everything do here was just AP implementation.

I originally didn't look too deep into this b/c I didn't know if Nikolaj was already working on this themselves, and if so how much work they would have already done on it in a local branch or such. But I took a closer look at it on a whim and got it hashed out quicker and easier than I expected to, so here it is.

Suggested Labels:

- [enhancement](https://github.com/NikolajDanger/APSly2/issues?q=state%3Aopen%20label%3Aenhancement)